### PR TITLE
SDIC - raise exception if query got interrupted

### DIFF
--- a/sdic/constants.py
+++ b/sdic/constants.py
@@ -1,1 +1,1 @@
-VERSION = u'0.1'
+VERSION = u'0.2'

--- a/sdic/main.py
+++ b/sdic/main.py
@@ -28,6 +28,7 @@ import syslog
 
 from sqlalchemy import create_engine
 from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
 
 from docopt import docopt
 from constants import VERSION
@@ -77,7 +78,13 @@ def launch_queries(directory, server):
             query = opened_file.read()
 
             start_time = time.time()
-            output = get_query_output(server, query)
+            try:
+                output = get_query_output(server, query)
+            except DBAPIError:
+                print "The following SQL query got interrupted:"
+                print query
+                print
+                continue
             query_time = round(time.time() - start_time, 3)
 
             syslog.syslog('{} successfully ran in {} sec.'.format(filename,


### PR DESCRIPTION
https://app.asana.com/0/20810103798902/158656695251449

See below when tested:

``` bash
The following SQL query got interrupted:
-- content serviceposts should have a parent post through posts_serviceposts...
SELECT sp.*, p.poid
FROM service_posts sp...
LIMIT 10;


The following SQL query got interrupted:
-- This query should return nothing.  If we get results it means that an object...
SELECT `schema_id`,`name`,`object_uid`, count(*)
FROM `form_value`...
LIMIT 10;
```
